### PR TITLE
Display lab duration without `read`

### DIFF
--- a/index.html
+++ b/index.html
@@ -497,7 +497,7 @@
             <img alt="" src="${item.thumbnail || DEFAULT_THUMBNAIL}"/>
             </coral-card-asset>
             <coral-card-content>
-            <coral-card-context>${item.author ? `${item.author} -` : ''} ${item.published} ${item.duration ? `- ${item.duration} min read` : ''}</coral-card-context>
+            <coral-card-context>${item.author ? `${item.author} -` : ''} ${item.published} ${item.duration ? `- ${item.duration} min` : ''}</coral-card-context>
               <coral-card-title><strong>${item.title}</strong></coral-card-title>
               <coral-card-description>${item.description}
                 ${item.keywords && item.keywords.length ? `


### PR DESCRIPTION
As a CodeLab is about doing stuff, displaying the duration by `10 min read` is not so relevant.
I propose to display `10 min` only.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
