### PR TITLE
Add GitHub actions for auto deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: AIO App CI
+
+on: [release]
+jobs:
+  deploy:
+    name: Deploy to Prod
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 1
+      matrix:
+        node-version: ['12']
+        os: [ubuntu-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: npm install
+        run: npm i
+      - name: Setup CLI
+        uses: adobe/aio-cli-setup-action@0.0.1
+        with:
+          os: ${{ matrix.os }}
+      - name: Build
+        uses: adobe/aio-apps-action@0.0.1
+        with:
+          os: ${{ matrix.os }}
+          command: build
+          AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE }}
+      - name: Deploy
+        uses: adobe/aio-apps-action@0.0.1
+        with:
+          os: ${{ matrix.os }}
+          command: deploy
+          AIO_RUNTIME_AUTH: ${{ secrets.AIO_RUNTIME_AUTH }}
+          AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE }}

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -1,6 +1,9 @@
 name: AIO App CI
 
-on: [release]
+on:
+  push:
+    branches:
+      - gh-pages
 jobs:
   deploy:
     name: Deploy to Prod

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -29,8 +29,6 @@ jobs:
           os: ${{ matrix.os }}
           command: build
           AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_PROD }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.AIO_GITHUB_TOKEN_PROD }}
       - name: Deploy
         uses: adobe/aio-apps-action@0.0.1
         with:

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -28,11 +28,11 @@ jobs:
         with:
           os: ${{ matrix.os }}
           command: build
-          AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE }}
+          AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_PROD }}
       - name: Deploy
         uses: adobe/aio-apps-action@0.0.1
         with:
           os: ${{ matrix.os }}
           command: deploy
-          AIO_RUNTIME_AUTH: ${{ secrets.AIO_RUNTIME_AUTH }}
-          AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE }}
+          AIO_RUNTIME_AUTH: ${{ secrets.AIO_RUNTIME_AUTH_PROD }}
+          AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_PROD }}

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -29,6 +29,7 @@ jobs:
           os: ${{ matrix.os }}
           command: build
           AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_PROD }}
+        env:
           GITHUB_TOKEN: ${{ secrets.AIO_GITHUB_TOKEN_PROD }}
       - name: Deploy
         uses: adobe/aio-apps-action@0.0.1
@@ -37,4 +38,5 @@ jobs:
           command: deploy
           AIO_RUNTIME_AUTH: ${{ secrets.AIO_RUNTIME_AUTH_PROD }}
           AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_PROD }}
+        env:
           GITHUB_TOKEN: ${{ secrets.AIO_GITHUB_TOKEN_PROD }}

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -29,6 +29,7 @@ jobs:
           os: ${{ matrix.os }}
           command: build
           AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_PROD }}
+          GITHUB_TOKEN: ${{ secrets.AIO_GITHUB_TOKEN_PROD }}
       - name: Deploy
         uses: adobe/aio-apps-action@0.0.1
         with:

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -37,3 +37,4 @@ jobs:
           command: deploy
           AIO_RUNTIME_AUTH: ${{ secrets.AIO_RUNTIME_AUTH_PROD }}
           AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_PROD }}
+          GITHUB_TOKEN: ${{ secrets.AIO_GITHUB_TOKEN_PROD }}

--- a/.github/workflows/deploy_stage.yml
+++ b/.github/workflows/deploy_stage.yml
@@ -40,3 +40,4 @@ jobs:
           command: deploy
           AIO_RUNTIME_AUTH: ${{ secrets.AIO_RUNTIME_AUTH_STAGE }}
           AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_STAGE }}
+          GITHUB_TOKEN: ${{ secrets.AIO_GITHUB_TOKEN_STAGE }}

--- a/.github/workflows/deploy_stage.yml
+++ b/.github/workflows/deploy_stage.yml
@@ -3,7 +3,7 @@ name: AIO App CI
 on:
   push:
     branches:
-      - duy/github-action
+      - gh-pages
 jobs:
   deploy:
     name: Deploy to Stage

--- a/.github/workflows/deploy_stage.yml
+++ b/.github/workflows/deploy_stage.yml
@@ -32,6 +32,7 @@ jobs:
           os: ${{ matrix.os }}
           command: build
           AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_STAGE }}
+          GITHUB_TOKEN: ${{ secrets.AIO_GITHUB_TOKEN_STAGE }}
       - name: Deploy
         uses: adobe/aio-apps-action@0.0.1
         with:

--- a/.github/workflows/deploy_stage.yml
+++ b/.github/workflows/deploy_stage.yml
@@ -32,6 +32,7 @@ jobs:
           os: ${{ matrix.os }}
           command: build
           AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_STAGE }}
+        env:
           GITHUB_TOKEN: ${{ secrets.AIO_GITHUB_TOKEN_STAGE }}
       - name: Deploy
         uses: adobe/aio-apps-action@0.0.1
@@ -40,4 +41,5 @@ jobs:
           command: deploy
           AIO_RUNTIME_AUTH: ${{ secrets.AIO_RUNTIME_AUTH_STAGE }}
           AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_STAGE }}
+        env:
           GITHUB_TOKEN: ${{ secrets.AIO_GITHUB_TOKEN_STAGE }}

--- a/.github/workflows/deploy_stage.yml
+++ b/.github/workflows/deploy_stage.yml
@@ -32,8 +32,6 @@ jobs:
           os: ${{ matrix.os }}
           command: build
           AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_STAGE }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.AIO_GITHUB_TOKEN_STAGE }}
       - name: Deploy
         uses: adobe/aio-apps-action@0.0.1
         with:

--- a/.github/workflows/deploy_stage.yml
+++ b/.github/workflows/deploy_stage.yml
@@ -3,7 +3,7 @@ name: AIO App CI
 on:
   push:
     branches:
-      - gh-pages
+      - master
 jobs:
   deploy:
     name: Deploy to Stage

--- a/.github/workflows/deploy_stage.yml
+++ b/.github/workflows/deploy_stage.yml
@@ -1,0 +1,41 @@
+name: AIO App CI
+
+on:
+  push:
+    branches:
+      - duy/github-action
+jobs:
+  deploy:
+    name: Deploy to Stage
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 1
+      matrix:
+        node-version: ['12']
+        os: [ubuntu-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: npm install
+        run: npm i
+      - name: Setup CLI
+        uses: adobe/aio-cli-setup-action@0.0.1
+        with:
+          os: ${{ matrix.os }}
+      - name: Build
+        uses: adobe/aio-apps-action@0.0.1
+        with:
+          os: ${{ matrix.os }}
+          command: build
+          AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_STAGE }}
+      - name: Deploy
+        uses: adobe/aio-apps-action@0.0.1
+        with:
+          os: ${{ matrix.os }}
+          command: deploy
+          AIO_RUNTIME_AUTH: ${{ secrets.AIO_RUNTIME_AUTH_STAGE }}
+          AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_STAGE }}

--- a/actions/search/index.js
+++ b/actions/search/index.js
@@ -1,7 +1,7 @@
 const fetch = require('node-fetch');
 const {Core} = require('@adobe/aio-sdk');
 const index = require('../index.json');
-const secret = require('./secret.json');
+// const secret = require('./secret.json');
 
 async function main(params) {
   const logger = Core.Logger('main', {level: params.LOG_LEVEL});
@@ -19,8 +19,8 @@ async function main(params) {
     // todo verify v4 API with GraphQL
     const search = await fetch(`https://api.github.com/search/code?q=${repos}+extension:md+in:file+${query}&per_page=${limit}&sort=${sort}`, {
       headers: {
-        'user-agent': 'node.js',
-        'Authorization': `token ${secret.token}`
+        'user-agent': 'node.js'
+        // 'Authorization': `token ${secret.token}`
       }
     });
   

--- a/actions/search/index.js
+++ b/actions/search/index.js
@@ -1,7 +1,6 @@
 const fetch = require('node-fetch');
 const {Core} = require('@adobe/aio-sdk');
 const index = require('../index.json');
-// const secret = require('./secret.json');
 
 async function main(params) {
   const logger = Core.Logger('main', {level: params.LOG_LEVEL});
@@ -19,8 +18,8 @@ async function main(params) {
     // todo verify v4 API with GraphQL
     const search = await fetch(`https://api.github.com/search/code?q=${repos}+extension:md+in:file+${query}&per_page=${limit}&sort=${sort}`, {
       headers: {
-        'user-agent': 'node.js'
-        // 'Authorization': `token ${secret.token}`
+        'user-agent': 'node.js',
+        'Authorization': `token ${params.github_token}`
       }
     });
   

--- a/index.html
+++ b/index.html
@@ -541,7 +541,7 @@
       // Init navigation
       (async () => {
         if (!storage.index) {
-          const INDEX_ACTION = 'https://adobeioruntime.net/api/v1/web/ringel/aio-codelabs-0.0.1/index';
+          const INDEX_ACTION = 'https://adobeioruntime.net/api/v1/web/aioe-demo/aio-codelabs-0.0.1/index';
           const find = await fetch(INDEX_ACTION);
           // Store the index locally for autocomplete
           storage.index = await find.text();
@@ -580,7 +580,7 @@
 
       // Init Search
       (() => {
-        const SEARCH_ACTION = 'https://adobeioruntime.net/api/v1/web/ringel/aio-codelabs-0.0.1/search';
+        const SEARCH_ACTION = 'https://adobeioruntime.net/api/v1/web/aioe-demo/aio-codelabs-0.0.1/search';
 
         const closeAutocomplete = () => {
           searchAutocomplete.target = null;

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,6 +8,7 @@ packages:
         runtime: 'nodejs:10'
         inputs:
           LOG_LEVEL: debug
+          github_token: GITHUB_TOKEN
         annotations:
           final: true
       index:

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,7 +8,7 @@ packages:
         runtime: 'nodejs:10'
         inputs:
           LOG_LEVEL: debug
-          github_token: GITHUB_TOKEN
+          github_token: $GITHUB_TOKEN
         annotations:
           final: true
       index:


### PR DESCRIPTION
Adding 2 GitHub actions that takes care of deploying the runtime actions upon:
1. commits to `gh-pages` branch: deploy to stage
2. creation of a release: deploy to prod

For now both stage and prod uses the same namespace `aioe-demo`. Later TBD.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
